### PR TITLE
generate arginfo from stub

### DIFF
--- a/componere.c
+++ b/componere.c
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | componere                                                            |
   +----------------------------------------------------------------------+
-  | Copyright (c) Joe Watkins 2018-2019                                  |
+  | Copyright (c) Joe Watkins 2018-2020                                  |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |
@@ -31,6 +31,12 @@
 #include <src/method.h>
 #include <src/reflection.h>
 #include <src/value.h>
+
+#if PHP_VERSION_ID < 80000
+#include "componere_legacy_arginfo.h"
+#else
+#include "componere_arginfo.h"
+#endif
 
 zend_string *php_componere_name_function;
 
@@ -118,12 +124,7 @@ PHP_MINFO_FUNCTION(componere)
 }
 /* }}} */
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_cast_arginfo, 0, 0, 2)
-       ZEND_ARG_INFO(0, Type)
-       ZEND_ARG_INFO(0, object)
-ZEND_END_ARG_INFO()
-
-PHP_FUNCTION(Componere_cast)
+PHP_FUNCTION(cast)
 {
        zend_class_entry *target = NULL;
        zval *object = NULL;
@@ -136,7 +137,7 @@ PHP_FUNCTION(Componere_cast)
        php_componere_cast(return_value, object, target, 0);
 }
 
-PHP_FUNCTION(Componere_cast_by_ref)
+PHP_FUNCTION(cast_by_ref)
 {
        zend_class_entry *target = NULL;
        zval *object = NULL;
@@ -148,15 +149,6 @@ PHP_FUNCTION(Componere_cast_by_ref)
 
        php_componere_cast(return_value, object, target, 1);
 }
-
-/* {{{ componere_functions[]
- */
-static const zend_function_entry componere_functions[] = {
-        ZEND_NS_NAMED_FE("Componere", cast, zif_Componere_cast, php_componere_cast_arginfo)
-        ZEND_NS_NAMED_FE("Componere", cast_by_ref, zif_Componere_cast_by_ref, php_componere_cast_arginfo)
-	PHP_FE_END
-};
-/* }}} */
 
 /* {{{ componere_module_deps[] */
 static const zend_module_dep componere_module_deps[] = {
@@ -171,7 +163,7 @@ zend_module_entry componere_module_entry = {
 	NULL,
 	componere_module_deps,
 	"componere",
-	componere_functions,
+	ext_functions,
 	PHP_MINIT(componere),
 	PHP_MSHUTDOWN(componere),
 	PHP_RINIT(componere),

--- a/componere.stub.php
+++ b/componere.stub.php
@@ -7,7 +7,15 @@
 
 namespace Componere;
 
-function cast(string $Type, mixed $object): mixed {}
+/**
+ * @param mixed $object
+ * @return mixed
+ */
+function cast(string $Type, $object) {}
 
-function cast_by_ref(string $Type, mixed $object): mixed {}
+/**
+ * @param mixed $object
+ * @return mixed
+ */
+function cast_by_ref(string $Type, $object) {}
 

--- a/componere.stub.php
+++ b/componere.stub.php
@@ -7,15 +7,7 @@
 
 namespace Componere;
 
-/**
- * @param mixed $object
- * @return mixed
- */
-function cast(string $Type, $object) {}
+function cast(string $Type, object $object):object {}
 
-/**
- * @param mixed $object
- * @return mixed
- */
-function cast_by_ref(string $Type, $object) {}
+function cast_by_ref(string $Type, object $object):object {}
 

--- a/componere.stub.php
+++ b/componere.stub.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+namespace Componere;
+
+function cast(string $Type, mixed $object): mixed {}
+
+function cast_by_ref(string $Type, mixed $object): mixed {}
+

--- a/componere_arginfo.h
+++ b/componere_arginfo.h
@@ -1,0 +1,20 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 8b591539e52e4484b6b37c90d804e8c9f00534e2 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Componere_cast, 0, 2, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, Type, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, object, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_Componere_cast_by_ref arginfo_Componere_cast
+
+
+ZEND_FUNCTION(cast);
+ZEND_FUNCTION(cast_by_ref);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_NS_FE("Componere", cast, arginfo_Componere_cast)
+	ZEND_NS_FE("Componere", cast_by_ref, arginfo_Componere_cast_by_ref)
+	ZEND_FE_END
+};

--- a/componere_arginfo.h
+++ b/componere_arginfo.h
@@ -1,9 +1,9 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8b591539e52e4484b6b37c90d804e8c9f00534e2 */
+ * Stub hash: 8d40613399ac3dc3a114a854968f46765633bb24 */
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Componere_cast, 0, 2, IS_MIXED, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_Componere_cast, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, Type, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, object, IS_MIXED, 0)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
 #define arginfo_Componere_cast_by_ref arginfo_Componere_cast

--- a/componere_arginfo.h
+++ b/componere_arginfo.h
@@ -1,9 +1,9 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8d40613399ac3dc3a114a854968f46765633bb24 */
+ * Stub hash: a932abc5116ff48bc96657b1476a3d73dddc49cf */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_Componere_cast, 0, 0, 2)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Componere_cast, 0, 2, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_INFO(0, Type, IS_STRING, 0)
-	ZEND_ARG_INFO(0, object)
+	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_Componere_cast_by_ref arginfo_Componere_cast

--- a/componere_legacy_arginfo.h
+++ b/componere_legacy_arginfo.h
@@ -1,0 +1,20 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 8b591539e52e4484b6b37c90d804e8c9f00534e2 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_Componere_cast, 0, 0, 2)
+	ZEND_ARG_INFO(0, Type)
+	ZEND_ARG_INFO(0, object)
+ZEND_END_ARG_INFO()
+
+#define arginfo_Componere_cast_by_ref arginfo_Componere_cast
+
+
+ZEND_FUNCTION(cast);
+ZEND_FUNCTION(cast_by_ref);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_NS_FE("Componere", cast, arginfo_Componere_cast)
+	ZEND_NS_FE("Componere", cast_by_ref, arginfo_Componere_cast_by_ref)
+	ZEND_FE_END
+};

--- a/componere_legacy_arginfo.h
+++ b/componere_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8d40613399ac3dc3a114a854968f46765633bb24 */
+ * Stub hash: a932abc5116ff48bc96657b1476a3d73dddc49cf */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_Componere_cast, 0, 0, 2)
 	ZEND_ARG_INFO(0, Type)

--- a/componere_legacy_arginfo.h
+++ b/componere_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8b591539e52e4484b6b37c90d804e8c9f00534e2 */
+ * Stub hash: 8d40613399ac3dc3a114a854968f46765633bb24 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_Componere_cast, 0, 0, 2)
 	ZEND_ARG_INFO(0, Type)

--- a/src/common.h
+++ b/src/common.h
@@ -169,10 +169,4 @@ static inline void php_componere_setup_handlers(
 	handlers->offset = offset;
 }
 
-ZEND_BEGIN_ARG_INFO(php_componere_no_arginfo, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(php_componere_ignore_arginfo, 1)
-	ZEND_ARG_VARIADIC_INFO(0, arguments)
-ZEND_END_ARG_INFO()
 #endif

--- a/src/definition.c
+++ b/src/definition.c
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | componere                                                            |
   +----------------------------------------------------------------------+
-  | Copyright (c) Joe Watkins 2018-2019                                  |
+  | Copyright (c) Joe Watkins 2018-2020                                  |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |
@@ -34,6 +34,13 @@
 #include <src/definition.h>
 #include <src/method.h>
 #include <src/value.h>
+
+#if PHP_VERSION_ID < 80000
+#include "definition_legacy_arginfo.h"
+#else
+#include "definition_arginfo.h"
+#endif
+
 
 zend_class_entry *php_componere_definition_abstract_ce;
 zend_class_entry *php_componere_definition_ce;
@@ -450,7 +457,7 @@ static inline void php_componere_definition_destroy(zend_object *zo) {
 	zend_object_std_dtor(&o->std);
 }
 
-PHP_METHOD(Definition, __construct)
+PHP_METHOD(Componere_Definition, __construct)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_string *name = NULL;
@@ -650,7 +657,7 @@ void php_componere_definition_properties_table_rebuild(zend_class_entry *ce)
 }
 #endif
 
-PHP_METHOD(Definition, register)
+PHP_METHOD(Componere_Definition, register)
 {
 	php_componere_definition_t *o = 
 		php_componere_definition_fetch(getThis());
@@ -715,12 +722,7 @@ PHP_METHOD(Definition, register)
 #endif
 }
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_definition_method, 0, 0, 2)
-	ZEND_ARG_INFO(0, name)
-	ZEND_ARG_INFO(0, method)
-ZEND_END_ARG_INFO()
-
-PHP_METHOD(Definition, addMethod)
+PHP_METHOD(Componere_Abstract_Definition, addMethod)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_string *name = NULL, *key;
@@ -802,11 +804,7 @@ PHP_METHOD(Definition, addMethod)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_definition_trait, 0, 0, 1)
-	ZEND_ARG_INFO(0, trait)
-ZEND_END_ARG_INFO()
-
-PHP_METHOD(Definition, addTrait)
+PHP_METHOD(Componere_Abstract_Definition, addTrait)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_class_entry *trait = NULL;
@@ -865,11 +863,7 @@ PHP_METHOD(Definition, addTrait)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_definition_interface, 0, 0, 1)
-	ZEND_ARG_INFO(0, interface)
-ZEND_END_ARG_INFO()
-
-PHP_METHOD(Definition, addInterface)
+PHP_METHOD(Componere_Abstract_Definition, addInterface)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_class_entry *interface = NULL;
@@ -897,11 +891,6 @@ PHP_METHOD(Definition, addInterface)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_definition_property, 0, 0, 2)
-	ZEND_ARG_INFO(0, name)
-	ZEND_ARG_INFO(0, value)
-ZEND_END_ARG_INFO()
-
 static zend_always_inline zend_bool php_componere_property_check(zend_objects_store *objects, php_componere_definition_t *def) {
 	
 	if (objects->top > 1) {
@@ -925,7 +914,7 @@ static zend_always_inline zend_bool php_componere_property_check(zend_objects_st
 	return 1;
 }
 
-PHP_METHOD(Definition, addProperty)
+PHP_METHOD(Componere_Definition, addProperty)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_string *name = NULL;
@@ -991,12 +980,7 @@ PHP_METHOD(Definition, addProperty)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_definition_constant, 0, 0, 2)
-	ZEND_ARG_INFO(0, name)
-	ZEND_ARG_INFO(0, property)
-ZEND_END_ARG_INFO()
-
-PHP_METHOD(Definition, addConstant)
+PHP_METHOD(Componere_Definition, addConstant)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_string *name = NULL;
@@ -1043,7 +1027,7 @@ PHP_METHOD(Definition, addConstant)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-PHP_METHOD(Definition, setConstant)
+PHP_METHOD(Componere_Definition, setConstant)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_string *name = NULL;
@@ -1094,11 +1078,7 @@ PHP_METHOD(Definition, setConstant)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_definition_closure, 0, 0, 1)
-	ZEND_ARG_INFO(0, name)
-ZEND_END_ARG_INFO()
-
-PHP_METHOD(Definition, getClosure)
+PHP_METHOD(Componere_Definition, getClosure)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_string *name = NULL;
@@ -1125,7 +1105,7 @@ PHP_METHOD(Definition, getClosure)
 	zend_string_release(key);
 }
 
-PHP_METHOD(Definition, getClosures)
+PHP_METHOD(Componere_Definition, getClosures)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_function *function = NULL;
@@ -1149,7 +1129,7 @@ PHP_METHOD(Definition, getClosures)
 	} ZEND_HASH_FOREACH_END();
 }
 
-PHP_METHOD(Definition, isRegistered)
+PHP_METHOD(Componere_Definition, isRegistered)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 
@@ -1158,7 +1138,7 @@ PHP_METHOD(Definition, isRegistered)
 	RETURN_BOOL(o->registered);
 }
 
-PHP_METHOD(Definition, getReflector)
+PHP_METHOD(Componere_Abstract_Definition, getReflector)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 
@@ -1178,35 +1158,16 @@ PHP_METHOD(Definition, getReflector)
 	RETURN_ZVAL(&o->reflector, 1, 0);
 }
 
-static zend_function_entry php_componere_definition_abstract_methods[] = {
-	PHP_ME(Definition, addMethod, php_componere_definition_method, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, addTrait, php_componere_definition_trait, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, addInterface, php_componere_definition_interface, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, getReflector, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
-
-static zend_function_entry php_componere_definition_methods[] = {
-	PHP_ME(Definition, __construct, php_componere_ignore_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, addProperty, php_componere_definition_property, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, addConstant, php_componere_definition_constant, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, setConstant, php_componere_definition_constant, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, getClosure, php_componere_definition_closure, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, getClosures, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, register, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Definition, isRegistered, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
 
 PHP_MINIT_FUNCTION(Componere_Definition) {
 	zend_class_entry ce;
 
-	INIT_NS_CLASS_ENTRY(ce, "Componere\\Abstract", "Definition", php_componere_definition_abstract_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Componere\\Abstract", "Definition", class_Componere_Abstract_Definition_methods);
 
 	php_componere_definition_abstract_ce = zend_register_internal_class(&ce);
 	php_componere_definition_abstract_ce->ce_flags |= ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 
-	INIT_NS_CLASS_ENTRY(ce, "Componere", "Definition", php_componere_definition_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Componere", "Definition", class_Componere_Definition_methods);
 
 	php_componere_definition_ce = zend_register_internal_class_ex(&ce, php_componere_definition_abstract_ce);
 	php_componere_definition_ce->create_object = php_componere_definition_create;

--- a/src/definition.stub.php
+++ b/src/definition.stub.php
@@ -25,7 +25,7 @@ abstract class Definition extends Abstract\Definition {
 	/**
 	 * @param mixed $arguments
 	 */
-	public function __construct(...$arguments) {}
+	public function __construct(string $name, ...$arguments) {}
 
 	public function addProperty(string $name, Value $value):static {}
 

--- a/src/definition.stub.php
+++ b/src/definition.stub.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+namespace Componere\Abstract;
+
+abstract class Definition {
+	public function addMethod(string $name, \Componere\Method $method):static {}
+
+	public function addTrait(string $trait):static {}
+
+	public function addInterface(string $interface):static {}
+
+	public function getReflector():\ReflectionClass {}
+}
+
+
+namespace Componere;
+
+abstract class Definition extends Abstract\Definition {
+
+	/**
+	 * @param mixed $arguments
+	 */
+	public function __construct(...$arguments) {}
+
+	public function addProperty(string $name, Value $value):static {}
+
+	public function addConstant(string $name, Value $value):static {}
+
+	public function setConstant(string $name, Value $value):static {}
+
+	public function getClosure(string $name):\Closure {}
+
+	public function getClosures():array {}
+
+	/**
+	 * @return void
+	 */
+	public function register() {}
+
+	public function isRegistered():bool {}
+}
+

--- a/src/definition_arginfo.h
+++ b/src/definition_arginfo.h
@@ -1,0 +1,80 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 5949e70343f7a1555409ac8211f4440948e52b3d */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Abstract_Definition_addMethod, 0, 2, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, method, Componere\\Method, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Abstract_Definition_addTrait, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, trait, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Abstract_Definition_addInterface, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, interface, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Componere_Abstract_Definition_getReflector, 0, 0, ReflectionClass, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition___construct, 0, 0, 0)
+	ZEND_ARG_VARIADIC_INFO(0, arguments)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Definition_addProperty, 0, 2, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, value, Componere\\Value, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Componere_Definition_addConstant arginfo_class_Componere_Definition_addProperty
+
+#define arginfo_class_Componere_Definition_setConstant arginfo_class_Componere_Definition_addProperty
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Componere_Definition_getClosure, 0, 1, Closure, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Definition_getClosures, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition_register, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Definition_isRegistered, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+
+ZEND_METHOD(Componere_Abstract_Definition, addMethod);
+ZEND_METHOD(Componere_Abstract_Definition, addTrait);
+ZEND_METHOD(Componere_Abstract_Definition, addInterface);
+ZEND_METHOD(Componere_Abstract_Definition, getReflector);
+ZEND_METHOD(Componere_Definition, __construct);
+ZEND_METHOD(Componere_Definition, addProperty);
+ZEND_METHOD(Componere_Definition, addConstant);
+ZEND_METHOD(Componere_Definition, setConstant);
+ZEND_METHOD(Componere_Definition, getClosure);
+ZEND_METHOD(Componere_Definition, getClosures);
+ZEND_METHOD(Componere_Definition, register);
+ZEND_METHOD(Componere_Definition, isRegistered);
+
+
+static const zend_function_entry class_Componere_Abstract_Definition_methods[] = {
+	ZEND_ME(Componere_Abstract_Definition, addMethod, arginfo_class_Componere_Abstract_Definition_addMethod, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Abstract_Definition, addTrait, arginfo_class_Componere_Abstract_Definition_addTrait, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Abstract_Definition, addInterface, arginfo_class_Componere_Abstract_Definition_addInterface, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Abstract_Definition, getReflector, arginfo_class_Componere_Abstract_Definition_getReflector, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Componere_Definition_methods[] = {
+	ZEND_ME(Componere_Definition, __construct, arginfo_class_Componere_Definition___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, addProperty, arginfo_class_Componere_Definition_addProperty, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, addConstant, arginfo_class_Componere_Definition_addConstant, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, setConstant, arginfo_class_Componere_Definition_setConstant, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, getClosure, arginfo_class_Componere_Definition_getClosure, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, getClosures, arginfo_class_Componere_Definition_getClosures, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, register, arginfo_class_Componere_Definition_register, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, isRegistered, arginfo_class_Componere_Definition_isRegistered, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/src/definition_arginfo.h
+++ b/src/definition_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5949e70343f7a1555409ac8211f4440948e52b3d */
+ * Stub hash: e02c82be4ca16c95473c30bff2d03369791007ae */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Abstract_Definition_addMethod, 0, 2, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
@@ -17,7 +17,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Componere_Abstract_Definition_getReflector, 0, 0, ReflectionClass, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition___construct, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_VARIADIC_INFO(0, arguments)
 ZEND_END_ARG_INFO()
 

--- a/src/definition_legacy_arginfo.h
+++ b/src/definition_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5949e70343f7a1555409ac8211f4440948e52b3d */
+ * Stub hash: e02c82be4ca16c95473c30bff2d03369791007ae */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Abstract_Definition_addMethod, 0, 0, 2)
 	ZEND_ARG_INFO(0, name)
@@ -17,7 +17,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Abstract_Definition_getReflector, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition___construct, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition___construct, 0, 0, 1)
+	ZEND_ARG_INFO(0, name)
 	ZEND_ARG_VARIADIC_INFO(0, arguments)
 ZEND_END_ARG_INFO()
 

--- a/src/definition_legacy_arginfo.h
+++ b/src/definition_legacy_arginfo.h
@@ -1,0 +1,77 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 5949e70343f7a1555409ac8211f4440948e52b3d */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Abstract_Definition_addMethod, 0, 0, 2)
+	ZEND_ARG_INFO(0, name)
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Abstract_Definition_addTrait, 0, 0, 1)
+	ZEND_ARG_INFO(0, trait)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Abstract_Definition_addInterface, 0, 0, 1)
+	ZEND_ARG_INFO(0, interface)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Abstract_Definition_getReflector, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition___construct, 0, 0, 0)
+	ZEND_ARG_VARIADIC_INFO(0, arguments)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition_addProperty, 0, 0, 2)
+	ZEND_ARG_INFO(0, name)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Componere_Definition_addConstant arginfo_class_Componere_Definition_addProperty
+
+#define arginfo_class_Componere_Definition_setConstant arginfo_class_Componere_Definition_addProperty
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Definition_getClosure, 0, 0, 1)
+	ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Componere_Definition_getClosures arginfo_class_Componere_Abstract_Definition_getReflector
+
+#define arginfo_class_Componere_Definition_register arginfo_class_Componere_Abstract_Definition_getReflector
+
+#define arginfo_class_Componere_Definition_isRegistered arginfo_class_Componere_Abstract_Definition_getReflector
+
+
+ZEND_METHOD(Componere_Abstract_Definition, addMethod);
+ZEND_METHOD(Componere_Abstract_Definition, addTrait);
+ZEND_METHOD(Componere_Abstract_Definition, addInterface);
+ZEND_METHOD(Componere_Abstract_Definition, getReflector);
+ZEND_METHOD(Componere_Definition, __construct);
+ZEND_METHOD(Componere_Definition, addProperty);
+ZEND_METHOD(Componere_Definition, addConstant);
+ZEND_METHOD(Componere_Definition, setConstant);
+ZEND_METHOD(Componere_Definition, getClosure);
+ZEND_METHOD(Componere_Definition, getClosures);
+ZEND_METHOD(Componere_Definition, register);
+ZEND_METHOD(Componere_Definition, isRegistered);
+
+
+static const zend_function_entry class_Componere_Abstract_Definition_methods[] = {
+	ZEND_ME(Componere_Abstract_Definition, addMethod, arginfo_class_Componere_Abstract_Definition_addMethod, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Abstract_Definition, addTrait, arginfo_class_Componere_Abstract_Definition_addTrait, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Abstract_Definition, addInterface, arginfo_class_Componere_Abstract_Definition_addInterface, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Abstract_Definition, getReflector, arginfo_class_Componere_Abstract_Definition_getReflector, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Componere_Definition_methods[] = {
+	ZEND_ME(Componere_Definition, __construct, arginfo_class_Componere_Definition___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, addProperty, arginfo_class_Componere_Definition_addProperty, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, addConstant, arginfo_class_Componere_Definition_addConstant, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, setConstant, arginfo_class_Componere_Definition_setConstant, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, getClosure, arginfo_class_Componere_Definition_getClosure, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, getClosures, arginfo_class_Componere_Definition_getClosures, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, register, arginfo_class_Componere_Definition_register, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Definition, isRegistered, arginfo_class_Componere_Definition_isRegistered, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/src/method.c
+++ b/src/method.c
@@ -98,7 +98,7 @@ static inline void php_componere_method_destroy(zend_object *zo) {
 	zend_object_std_dtor(&o->std);
 }
 
-PHP_METHOD(Method, __construct)
+PHP_METHOD(Componere_Method, __construct)
 {
 	php_componere_method_t *o = php_componere_method_fetch(getThis());
 	zval *closure = NULL;
@@ -133,7 +133,7 @@ PHP_METHOD(Method, __construct)
 	function_add_ref(o->function);
 }
 
-PHP_METHOD(Method, setProtected)
+PHP_METHOD(Componere_Method, setProtected)
 {
 	php_componere_method_t *o = php_componere_method_fetch(getThis());
 
@@ -149,7 +149,7 @@ PHP_METHOD(Method, setProtected)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-PHP_METHOD(Method, setPrivate)
+PHP_METHOD(Componere_Method, setPrivate)
 {
 	php_componere_method_t *o = php_componere_method_fetch(getThis());
 
@@ -165,7 +165,7 @@ PHP_METHOD(Method, setPrivate)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-PHP_METHOD(Method, setStatic)
+PHP_METHOD(Componere_Method, setStatic)
 {
 	php_componere_method_t *o = php_componere_method_fetch(getThis());
 
@@ -176,7 +176,7 @@ PHP_METHOD(Method, setStatic)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-PHP_METHOD(Method, setFinal)
+PHP_METHOD(Componere_Method, setFinal)
 {
 	php_componere_method_t *o = php_componere_method_fetch(getThis());
 
@@ -187,7 +187,7 @@ PHP_METHOD(Method, setFinal)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-PHP_METHOD(Method, getReflector)
+PHP_METHOD(Componere_Method, getReflector)
 {
 	php_componere_method_t *o = php_componere_method_fetch(getThis());
 
@@ -210,7 +210,7 @@ PHP_METHOD(Method, getReflector)
 PHP_MINIT_FUNCTION(Componere_Method) {
 	zend_class_entry ce;
 
-	INIT_NS_CLASS_ENTRY(ce, "Componere", "Method", class_Method_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Componere", "Method", class_Componere_Method_methods);
 
 	php_componere_method_ce = zend_register_internal_class(&ce);
 	php_componere_method_ce->create_object = php_componere_method_create;

--- a/src/method.c
+++ b/src/method.c
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | componere                                                            |
   +----------------------------------------------------------------------+
-  | Copyright (c) Joe Watkins 2018-2019                                  |
+  | Copyright (c) Joe Watkins 2018-2020                                  |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |

--- a/src/method.c
+++ b/src/method.c
@@ -31,6 +31,12 @@
 #include <src/reflection.h>
 #include <src/method.h>
 
+#if PHP_VERSION_ID < 80000
+#include "method_legacy_arginfo.h"
+#else
+#include "method_arginfo.h"
+#endif
+
 zend_class_entry *php_componere_method_ce;
 zend_object_handlers php_componere_method_handlers;
 
@@ -91,10 +97,6 @@ static inline void php_componere_method_destroy(zend_object *zo) {
 
 	zend_object_std_dtor(&o->std);
 }
-
-ZEND_BEGIN_ARG_INFO_EX(php_componere_method_construct, 0, 0, 1)
-	ZEND_ARG_INFO(0, closure)
-ZEND_END_ARG_INFO()
 
 PHP_METHOD(Method, __construct)
 {
@@ -205,21 +207,10 @@ PHP_METHOD(Method, getReflector)
 	RETURN_ZVAL(&o->reflector, 1 , 0);
 }
 
-static zend_function_entry php_componere_method_methods[] = {
-	PHP_ME(Method, __construct, php_componere_method_construct, ZEND_ACC_PUBLIC)
-	PHP_ME(Method, setProtected, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Method, setPrivate, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Method, setStatic, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Method, setFinal, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-
-	PHP_ME(Method, getReflector, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
-
 PHP_MINIT_FUNCTION(Componere_Method) {
 	zend_class_entry ce;
 
-	INIT_NS_CLASS_ENTRY(ce, "Componere", "Method", php_componere_method_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Componere", "Method", class_Method_methods);
 
 	php_componere_method_ce = zend_register_internal_class(&ce);
 	php_componere_method_ce->create_object = php_componere_method_create;

--- a/src/method.stub.php
+++ b/src/method.stub.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+namespace Componere;
+
+class Method {
+
+	public function __construct(\Closure $closure) {}
+
+	public function setProtected():Method {}
+
+	public function setPrivate():Method {}
+
+	public function setStatic():Method {}
+
+	public function setFinal():Method {}
+
+	public function getReflector():\ReflectionMethod {}
+}

--- a/src/method_arginfo.h
+++ b/src/method_arginfo.h
@@ -1,37 +1,37 @@
 /* This is a generated file, edit the .stub.php file instead.
  * Stub hash: bec40f676dddd349354623c052007d03fd5bd97b */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Method___construct, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Method___construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, closure, Closure, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Method_setProtected, 0, 0, Componere\\Method, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Componere_Method_setProtected, 0, 0, Componere\\Method, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Method_setPrivate arginfo_class_Method_setProtected
+#define arginfo_class_Componere_Method_setPrivate arginfo_class_Componere_Method_setProtected
 
-#define arginfo_class_Method_setStatic arginfo_class_Method_setProtected
+#define arginfo_class_Componere_Method_setStatic arginfo_class_Componere_Method_setProtected
 
-#define arginfo_class_Method_setFinal arginfo_class_Method_setProtected
+#define arginfo_class_Componere_Method_setFinal arginfo_class_Componere_Method_setProtected
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Method_getReflector, 0, 0, ReflectionMethod, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Componere_Method_getReflector, 0, 0, ReflectionMethod, 0)
 ZEND_END_ARG_INFO()
 
 
-ZEND_METHOD(Method, __construct);
-ZEND_METHOD(Method, setProtected);
-ZEND_METHOD(Method, setPrivate);
-ZEND_METHOD(Method, setStatic);
-ZEND_METHOD(Method, setFinal);
-ZEND_METHOD(Method, getReflector);
+ZEND_METHOD(Componere_Method, __construct);
+ZEND_METHOD(Componere_Method, setProtected);
+ZEND_METHOD(Componere_Method, setPrivate);
+ZEND_METHOD(Componere_Method, setStatic);
+ZEND_METHOD(Componere_Method, setFinal);
+ZEND_METHOD(Componere_Method, getReflector);
 
 
-static const zend_function_entry class_Method_methods[] = {
-	ZEND_ME(Method, __construct, arginfo_class_Method___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, setProtected, arginfo_class_Method_setProtected, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, setPrivate, arginfo_class_Method_setPrivate, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, setStatic, arginfo_class_Method_setStatic, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, setFinal, arginfo_class_Method_setFinal, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, getReflector, arginfo_class_Method_getReflector, ZEND_ACC_PUBLIC)
+static const zend_function_entry class_Componere_Method_methods[] = {
+	ZEND_ME(Componere_Method, __construct, arginfo_class_Componere_Method___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, setProtected, arginfo_class_Componere_Method_setProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, setPrivate, arginfo_class_Componere_Method_setPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, setStatic, arginfo_class_Componere_Method_setStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, setFinal, arginfo_class_Componere_Method_setFinal, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, getReflector, arginfo_class_Componere_Method_getReflector, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/src/method_arginfo.h
+++ b/src/method_arginfo.h
@@ -1,0 +1,37 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: bec40f676dddd349354623c052007d03fd5bd97b */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Method___construct, 0, 0, 1)
+	ZEND_ARG_OBJ_INFO(0, closure, Closure, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Method_setProtected, 0, 0, Componere\\Method, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Method_setPrivate arginfo_class_Method_setProtected
+
+#define arginfo_class_Method_setStatic arginfo_class_Method_setProtected
+
+#define arginfo_class_Method_setFinal arginfo_class_Method_setProtected
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Method_getReflector, 0, 0, ReflectionMethod, 0)
+ZEND_END_ARG_INFO()
+
+
+ZEND_METHOD(Method, __construct);
+ZEND_METHOD(Method, setProtected);
+ZEND_METHOD(Method, setPrivate);
+ZEND_METHOD(Method, setStatic);
+ZEND_METHOD(Method, setFinal);
+ZEND_METHOD(Method, getReflector);
+
+
+static const zend_function_entry class_Method_methods[] = {
+	ZEND_ME(Method, __construct, arginfo_class_Method___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, setProtected, arginfo_class_Method_setProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, setPrivate, arginfo_class_Method_setPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, setStatic, arginfo_class_Method_setStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, setFinal, arginfo_class_Method_setFinal, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, getReflector, arginfo_class_Method_getReflector, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/src/method_legacy_arginfo.h
+++ b/src/method_legacy_arginfo.h
@@ -1,0 +1,36 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: bec40f676dddd349354623c052007d03fd5bd97b */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Method___construct, 0, 0, 1)
+	ZEND_ARG_INFO(0, closure)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Method_setProtected, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Method_setPrivate arginfo_class_Method_setProtected
+
+#define arginfo_class_Method_setStatic arginfo_class_Method_setProtected
+
+#define arginfo_class_Method_setFinal arginfo_class_Method_setProtected
+
+#define arginfo_class_Method_getReflector arginfo_class_Method_setProtected
+
+
+ZEND_METHOD(Method, __construct);
+ZEND_METHOD(Method, setProtected);
+ZEND_METHOD(Method, setPrivate);
+ZEND_METHOD(Method, setStatic);
+ZEND_METHOD(Method, setFinal);
+ZEND_METHOD(Method, getReflector);
+
+
+static const zend_function_entry class_Method_methods[] = {
+	ZEND_ME(Method, __construct, arginfo_class_Method___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, setProtected, arginfo_class_Method_setProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, setPrivate, arginfo_class_Method_setPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, setStatic, arginfo_class_Method_setStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, setFinal, arginfo_class_Method_setFinal, ZEND_ACC_PUBLIC)
+	ZEND_ME(Method, getReflector, arginfo_class_Method_getReflector, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/src/method_legacy_arginfo.h
+++ b/src/method_legacy_arginfo.h
@@ -1,36 +1,36 @@
 /* This is a generated file, edit the .stub.php file instead.
  * Stub hash: bec40f676dddd349354623c052007d03fd5bd97b */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Method___construct, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Method___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, closure)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Method_setProtected, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Method_setProtected, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Method_setPrivate arginfo_class_Method_setProtected
+#define arginfo_class_Componere_Method_setPrivate arginfo_class_Componere_Method_setProtected
 
-#define arginfo_class_Method_setStatic arginfo_class_Method_setProtected
+#define arginfo_class_Componere_Method_setStatic arginfo_class_Componere_Method_setProtected
 
-#define arginfo_class_Method_setFinal arginfo_class_Method_setProtected
+#define arginfo_class_Componere_Method_setFinal arginfo_class_Componere_Method_setProtected
 
-#define arginfo_class_Method_getReflector arginfo_class_Method_setProtected
-
-
-ZEND_METHOD(Method, __construct);
-ZEND_METHOD(Method, setProtected);
-ZEND_METHOD(Method, setPrivate);
-ZEND_METHOD(Method, setStatic);
-ZEND_METHOD(Method, setFinal);
-ZEND_METHOD(Method, getReflector);
+#define arginfo_class_Componere_Method_getReflector arginfo_class_Componere_Method_setProtected
 
 
-static const zend_function_entry class_Method_methods[] = {
-	ZEND_ME(Method, __construct, arginfo_class_Method___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, setProtected, arginfo_class_Method_setProtected, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, setPrivate, arginfo_class_Method_setPrivate, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, setStatic, arginfo_class_Method_setStatic, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, setFinal, arginfo_class_Method_setFinal, ZEND_ACC_PUBLIC)
-	ZEND_ME(Method, getReflector, arginfo_class_Method_getReflector, ZEND_ACC_PUBLIC)
+ZEND_METHOD(Componere_Method, __construct);
+ZEND_METHOD(Componere_Method, setProtected);
+ZEND_METHOD(Componere_Method, setPrivate);
+ZEND_METHOD(Componere_Method, setStatic);
+ZEND_METHOD(Componere_Method, setFinal);
+ZEND_METHOD(Componere_Method, getReflector);
+
+
+static const zend_function_entry class_Componere_Method_methods[] = {
+	ZEND_ME(Componere_Method, __construct, arginfo_class_Componere_Method___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, setProtected, arginfo_class_Componere_Method_setProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, setPrivate, arginfo_class_Componere_Method_setPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, setStatic, arginfo_class_Componere_Method_setStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, setFinal, arginfo_class_Componere_Method_setFinal, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Method, getReflector, arginfo_class_Componere_Method_getReflector, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/src/patch.c
+++ b/src/patch.c
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | componere                                                            |
   +----------------------------------------------------------------------+
-  | Copyright (c) Joe Watkins 2018-2019                                  |
+  | Copyright (c) Joe Watkins 2018-2020                                  |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |
@@ -31,6 +31,12 @@
 
 #include <src/common.h>
 #include <src/definition.h>
+
+#if PHP_VERSION_ID < 80000
+#include "patch_legacy_arginfo.h"
+#else
+#include "patch_arginfo.h"
+#endif
 
 zend_class_entry *php_componere_patch_ce;
 zend_object_handlers php_componere_patch_handlers;
@@ -69,7 +75,7 @@ static inline void php_componere_patch_destroy(zend_object *zo) {
 	zend_object_std_dtor(&o->std);
 }
 
-PHP_METHOD(Patch, __construct)
+PHP_METHOD(Componere_Patch, __construct)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_class_entry *pce = NULL;
@@ -176,7 +182,7 @@ PHP_METHOD(Patch, __construct)
 #endif
 }
 
-PHP_METHOD(Patch, apply)
+PHP_METHOD(Componere_Patch, apply)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_object *zo;
@@ -187,7 +193,7 @@ PHP_METHOD(Patch, apply)
 	zo->ce = o->ce;
 }
 
-PHP_METHOD(Patch, revert)
+PHP_METHOD(Componere_Patch, revert)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_object *zo;
@@ -198,11 +204,7 @@ PHP_METHOD(Patch, revert)
 	zo->ce = o->saved;
 }
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_patch_closure, 0, 0, 1)
-	ZEND_ARG_INFO(0, name)
-ZEND_END_ARG_INFO()
-
-PHP_METHOD(Patch, getClosure)
+PHP_METHOD(Componere_Patch, getClosure)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_string *name = NULL;
@@ -227,7 +229,7 @@ PHP_METHOD(Patch, getClosure)
 	zend_string_release(key);
 }
 
-PHP_METHOD(Patch, getClosures)
+PHP_METHOD(Componere_Patch, getClosures)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	zend_function *function = NULL;
@@ -246,7 +248,7 @@ PHP_METHOD(Patch, getClosures)
 	} ZEND_HASH_FOREACH_END();
 }
 
-PHP_METHOD(Patch, isApplied)
+PHP_METHOD(Componere_Patch, isApplied)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 
@@ -255,11 +257,7 @@ PHP_METHOD(Patch, isApplied)
 	RETURN_BOOL(Z_OBJCE(o->instance) == o->ce);
 }
 
-ZEND_BEGIN_ARG_INFO_EX(php_componere_patch_derive, 0, 0, 1)
-	ZEND_ARG_INFO(0, object)
-ZEND_END_ARG_INFO()
-
-PHP_METHOD(Patch, derive)
+PHP_METHOD(Componere_Patch, derive)
 {
 	php_componere_definition_t *o = php_componere_definition_fetch(getThis());
 	php_componere_definition_t *r;
@@ -333,21 +331,10 @@ PHP_METHOD(Patch, derive)
 #endif
 }
 
-static zend_function_entry php_componere_patch_methods[] = {
-	PHP_ME(Patch, __construct, php_componere_ignore_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Patch, getClosure, php_componere_patch_closure, ZEND_ACC_PUBLIC)
-	PHP_ME(Patch, getClosures, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Patch, apply, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Patch, revert, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Patch, isApplied, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Patch, derive, php_componere_patch_derive, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
-
 PHP_MINIT_FUNCTION(Componere_Patch) {
 	zend_class_entry ce;
 
-	INIT_NS_CLASS_ENTRY(ce, "Componere", "Patch", php_componere_patch_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Componere", "Patch", class_Componere_Patch_methods);
 	
 	php_componere_patch_ce = zend_register_internal_class_ex(&ce, php_componere_definition_abstract_ce);
 	php_componere_patch_ce->create_object = php_componere_patch_create;

--- a/src/patch.stub.php
+++ b/src/patch.stub.php
@@ -12,7 +12,7 @@ abstract class Patch extends Abstract\Definition {
 	/**
 	 * @param mixed $arguments
 	 */
-	public function __construct(...$arguments) {}
+	public function __construct(object $instance, ...$arguments) {}
 
 	public function getClosure(string $name):\Closure {}
 
@@ -31,9 +31,8 @@ abstract class Patch extends Abstract\Definition {
 	public function isApplied():bool {}
 
 	/**
-	 * @param mixed $object
 	 * @return void
 	 */
-	public function derive($object) {}
+	public function derive(object $object) {}
 }
 

--- a/src/patch.stub.php
+++ b/src/patch.stub.php
@@ -14,6 +14,10 @@ abstract class Patch extends Abstract\Definition {
 	 */
 	public function __construct(...$arguments) {}
 
+	public function getClosure(string $name):\Closure {}
+
+	public function getClosures():array {}
+
 	/**
 	 * @return void
 	 */
@@ -23,10 +27,6 @@ abstract class Patch extends Abstract\Definition {
 	 * @return void
 	 */
 	public function revert() {}
-
-	public function getClosure(string $name):\Closure {}
-
-	public function getClosures():array {}
 
 	public function isApplied():bool {}
 

--- a/src/patch.stub.php
+++ b/src/patch.stub.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+namespace Componere;
+
+abstract class Patch extends Abstract\Definition {
+
+	/**
+	 * @param mixed $arguments
+	 */
+	public function __construct(...$arguments) {}
+
+	/**
+	 * @return void
+	 */
+	public function apply() {}
+
+	/**
+	 * @return void
+	 */
+	public function revert() {}
+
+	public function getClosure(string $name):\Closure {}
+
+	public function getClosures():array {}
+
+	public function isApplied():bool {}
+
+	/**
+	 * @param mixed $object
+	 * @return void
+	 */
+	public function derive($object) {}
+}
+

--- a/src/patch_arginfo.h
+++ b/src/patch_arginfo.h
@@ -1,7 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6ef7ca54e765828148371ba59be8ada41da72ac4 */
+ * Stub hash: 7bba7522aa6f3666cde11ddeb0dbcb4401871a0a */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch___construct, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, instance, IS_OBJECT, 0)
 	ZEND_ARG_VARIADIC_INFO(0, arguments)
 ZEND_END_ARG_INFO()
 
@@ -21,7 +22,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Patch_isApplied,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_derive, 0, 0, 1)
-	ZEND_ARG_INFO(0, object)
+	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
 

--- a/src/patch_arginfo.h
+++ b/src/patch_arginfo.h
@@ -1,0 +1,46 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: ea6a18ae27670a627d48e26e0d7923e84da82850 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch___construct, 0, 0, 0)
+	ZEND_ARG_VARIADIC_INFO(0, arguments)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_apply, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Componere_Patch_revert arginfo_class_Componere_Patch_apply
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Componere_Patch_getClosure, 0, 1, Closure, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Patch_getClosures, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Patch_isApplied, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_derive, 0, 0, 1)
+	ZEND_ARG_INFO(0, object)
+ZEND_END_ARG_INFO()
+
+
+ZEND_METHOD(Componere_Patch, __construct);
+ZEND_METHOD(Componere_Patch, apply);
+ZEND_METHOD(Componere_Patch, revert);
+ZEND_METHOD(Componere_Patch, getClosure);
+ZEND_METHOD(Componere_Patch, getClosures);
+ZEND_METHOD(Componere_Patch, isApplied);
+ZEND_METHOD(Componere_Patch, derive);
+
+
+static const zend_function_entry class_Componere_Patch_methods[] = {
+	ZEND_ME(Componere_Patch, __construct, arginfo_class_Componere_Patch___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, apply, arginfo_class_Componere_Patch_apply, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, revert, arginfo_class_Componere_Patch_revert, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, getClosure, arginfo_class_Componere_Patch_getClosure, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, getClosures, arginfo_class_Componere_Patch_getClosures, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, isApplied, arginfo_class_Componere_Patch_isApplied, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, derive, arginfo_class_Componere_Patch_derive, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/src/patch_arginfo.h
+++ b/src/patch_arginfo.h
@@ -1,14 +1,9 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ea6a18ae27670a627d48e26e0d7923e84da82850 */
+ * Stub hash: 6ef7ca54e765828148371ba59be8ada41da72ac4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch___construct, 0, 0, 0)
 	ZEND_ARG_VARIADIC_INFO(0, arguments)
 ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_apply, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-#define arginfo_class_Componere_Patch_revert arginfo_class_Componere_Patch_apply
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Componere_Patch_getClosure, 0, 1, Closure, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
@@ -16,6 +11,11 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Patch_getClosures, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_apply, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Componere_Patch_revert arginfo_class_Componere_Patch_apply
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Patch_isApplied, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
@@ -26,20 +26,20 @@ ZEND_END_ARG_INFO()
 
 
 ZEND_METHOD(Componere_Patch, __construct);
-ZEND_METHOD(Componere_Patch, apply);
-ZEND_METHOD(Componere_Patch, revert);
 ZEND_METHOD(Componere_Patch, getClosure);
 ZEND_METHOD(Componere_Patch, getClosures);
+ZEND_METHOD(Componere_Patch, apply);
+ZEND_METHOD(Componere_Patch, revert);
 ZEND_METHOD(Componere_Patch, isApplied);
 ZEND_METHOD(Componere_Patch, derive);
 
 
 static const zend_function_entry class_Componere_Patch_methods[] = {
 	ZEND_ME(Componere_Patch, __construct, arginfo_class_Componere_Patch___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME(Componere_Patch, apply, arginfo_class_Componere_Patch_apply, ZEND_ACC_PUBLIC)
-	ZEND_ME(Componere_Patch, revert, arginfo_class_Componere_Patch_revert, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Patch, getClosure, arginfo_class_Componere_Patch_getClosure, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Patch, getClosures, arginfo_class_Componere_Patch_getClosures, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, apply, arginfo_class_Componere_Patch_apply, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, revert, arginfo_class_Componere_Patch_revert, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Patch, isApplied, arginfo_class_Componere_Patch_isApplied, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Patch, derive, arginfo_class_Componere_Patch_derive, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/src/patch_legacy_arginfo.h
+++ b/src/patch_legacy_arginfo.h
@@ -1,0 +1,44 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: ea6a18ae27670a627d48e26e0d7923e84da82850 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch___construct, 0, 0, 0)
+	ZEND_ARG_VARIADIC_INFO(0, arguments)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_apply, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Componere_Patch_revert arginfo_class_Componere_Patch_apply
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_getClosure, 0, 0, 1)
+	ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Componere_Patch_getClosures arginfo_class_Componere_Patch_apply
+
+#define arginfo_class_Componere_Patch_isApplied arginfo_class_Componere_Patch_apply
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_derive, 0, 0, 1)
+	ZEND_ARG_INFO(0, object)
+ZEND_END_ARG_INFO()
+
+
+ZEND_METHOD(Componere_Patch, __construct);
+ZEND_METHOD(Componere_Patch, apply);
+ZEND_METHOD(Componere_Patch, revert);
+ZEND_METHOD(Componere_Patch, getClosure);
+ZEND_METHOD(Componere_Patch, getClosures);
+ZEND_METHOD(Componere_Patch, isApplied);
+ZEND_METHOD(Componere_Patch, derive);
+
+
+static const zend_function_entry class_Componere_Patch_methods[] = {
+	ZEND_ME(Componere_Patch, __construct, arginfo_class_Componere_Patch___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, apply, arginfo_class_Componere_Patch_apply, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, revert, arginfo_class_Componere_Patch_revert, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, getClosure, arginfo_class_Componere_Patch_getClosure, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, getClosures, arginfo_class_Componere_Patch_getClosures, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, isApplied, arginfo_class_Componere_Patch_isApplied, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, derive, arginfo_class_Componere_Patch_derive, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/src/patch_legacy_arginfo.h
+++ b/src/patch_legacy_arginfo.h
@@ -1,7 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6ef7ca54e765828148371ba59be8ada41da72ac4 */
+ * Stub hash: 7bba7522aa6f3666cde11ddeb0dbcb4401871a0a */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch___construct, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch___construct, 0, 0, 1)
+	ZEND_ARG_INFO(0, instance)
 	ZEND_ARG_VARIADIC_INFO(0, arguments)
 ZEND_END_ARG_INFO()
 

--- a/src/patch_legacy_arginfo.h
+++ b/src/patch_legacy_arginfo.h
@@ -1,22 +1,22 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ea6a18ae27670a627d48e26e0d7923e84da82850 */
+ * Stub hash: 6ef7ca54e765828148371ba59be8ada41da72ac4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch___construct, 0, 0, 0)
 	ZEND_ARG_VARIADIC_INFO(0, arguments)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_apply, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-#define arginfo_class_Componere_Patch_revert arginfo_class_Componere_Patch_apply
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_getClosure, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Componere_Patch_getClosures arginfo_class_Componere_Patch_apply
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_getClosures, 0, 0, 0)
+ZEND_END_ARG_INFO()
 
-#define arginfo_class_Componere_Patch_isApplied arginfo_class_Componere_Patch_apply
+#define arginfo_class_Componere_Patch_apply arginfo_class_Componere_Patch_getClosures
+
+#define arginfo_class_Componere_Patch_revert arginfo_class_Componere_Patch_getClosures
+
+#define arginfo_class_Componere_Patch_isApplied arginfo_class_Componere_Patch_getClosures
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Patch_derive, 0, 0, 1)
 	ZEND_ARG_INFO(0, object)
@@ -24,20 +24,20 @@ ZEND_END_ARG_INFO()
 
 
 ZEND_METHOD(Componere_Patch, __construct);
-ZEND_METHOD(Componere_Patch, apply);
-ZEND_METHOD(Componere_Patch, revert);
 ZEND_METHOD(Componere_Patch, getClosure);
 ZEND_METHOD(Componere_Patch, getClosures);
+ZEND_METHOD(Componere_Patch, apply);
+ZEND_METHOD(Componere_Patch, revert);
 ZEND_METHOD(Componere_Patch, isApplied);
 ZEND_METHOD(Componere_Patch, derive);
 
 
 static const zend_function_entry class_Componere_Patch_methods[] = {
 	ZEND_ME(Componere_Patch, __construct, arginfo_class_Componere_Patch___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME(Componere_Patch, apply, arginfo_class_Componere_Patch_apply, ZEND_ACC_PUBLIC)
-	ZEND_ME(Componere_Patch, revert, arginfo_class_Componere_Patch_revert, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Patch, getClosure, arginfo_class_Componere_Patch_getClosure, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Patch, getClosures, arginfo_class_Componere_Patch_getClosures, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, apply, arginfo_class_Componere_Patch_apply, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Patch, revert, arginfo_class_Componere_Patch_revert, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Patch, isApplied, arginfo_class_Componere_Patch_isApplied, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Patch, derive, arginfo_class_Componere_Patch_derive, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/src/value.c
+++ b/src/value.c
@@ -67,7 +67,7 @@ PHP_METHOD(Componere_Value, __construct)
 	zval *value = NULL;
 
 	if (php_componere_parse_parameters("|z", &value) != SUCCESS) {
-		php_componere_wrong_parameters("value expected");
+		php_componere_wrong_parameters("only optional value expected");
 		return;
 	}
 

--- a/src/value.c
+++ b/src/value.c
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | componere                                                            |
   +----------------------------------------------------------------------+
-  | Copyright (c) Joe Watkins 2018-2019                                  |
+  | Copyright (c) Joe Watkins 2018-2020                                  |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |
@@ -30,6 +30,12 @@
 #include <src/common.h>
 #include <src/value.h>
 
+#if PHP_VERSION_ID < 80000
+#include "value_legacy_arginfo.h"
+#else
+#include "value_arginfo.h"
+#endif
+
 zend_class_entry *php_componere_value_ce;
 zend_object_handlers php_componere_value_handlers;
 
@@ -54,10 +60,6 @@ static inline void php_componere_value_destroy(zend_object *zo) {
 
 	zend_object_std_dtor(&o->std);
 }
-
-ZEND_BEGIN_ARG_INFO_EX(php_componere_value_construct, 0, 0, 0)
-	ZEND_ARG_INFO(0, value)
-ZEND_END_ARG_INFO()
 
 PHP_METHOD(Value, __construct)
 {
@@ -178,24 +180,10 @@ PHP_METHOD(Value, hasDefault)
 	RETURN_BOOL(!Z_ISUNDEF(o->value));
 }
 
-static zend_function_entry php_componere_value_methods[] = {
-	PHP_ME(Value, __construct, php_componere_value_construct, ZEND_ACC_PUBLIC)
-	PHP_ME(Value, setProtected, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Value, setPrivate, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Value, setStatic, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-
-	PHP_ME(Value, isProtected, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Value, isPrivate, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_ME(Value, isStatic, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-
-	PHP_ME(Value, hasDefault, php_componere_no_arginfo, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
-
 PHP_MINIT_FUNCTION(Componere_Value) {
 	zend_class_entry ce;
 
-	INIT_NS_CLASS_ENTRY(ce, "Componere", "Value", php_componere_value_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Componere", "Value", class_Value_methods);
 
 	php_componere_value_ce = zend_register_internal_class(&ce);
 	php_componere_value_ce->create_object = php_componere_value_create;

--- a/src/value.c
+++ b/src/value.c
@@ -61,7 +61,7 @@ static inline void php_componere_value_destroy(zend_object *zo) {
 	zend_object_std_dtor(&o->std);
 }
 
-PHP_METHOD(Value, __construct)
+PHP_METHOD(Componere_Value, __construct)
 {
 	php_componere_value_t *o = php_componere_value_fetch(getThis());
 	zval *value = NULL;
@@ -101,7 +101,7 @@ PHP_METHOD(Value, __construct)
 	}
 }
 
-PHP_METHOD(Value, setProtected)
+PHP_METHOD(Componere_Value, setProtected)
 {
 	php_componere_value_t *o = php_componere_value_fetch(getThis());
 
@@ -117,7 +117,7 @@ PHP_METHOD(Value, setProtected)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-PHP_METHOD(Value, setPrivate)
+PHP_METHOD(Componere_Value, setPrivate)
 {
 	php_componere_value_t *o = php_componere_value_fetch(getThis());
 
@@ -133,7 +133,7 @@ PHP_METHOD(Value, setPrivate)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-PHP_METHOD(Value, setStatic)
+PHP_METHOD(Componere_Value, setStatic)
 {
 	php_componere_value_t *o = php_componere_value_fetch(getThis());
 
@@ -144,7 +144,7 @@ PHP_METHOD(Value, setStatic)
 	RETURN_ZVAL(getThis(), 1, 0);
 }
 
-PHP_METHOD(Value, isPrivate)
+PHP_METHOD(Componere_Value, isPrivate)
 {
 	php_componere_value_t *o = php_componere_value_fetch(getThis());
 
@@ -153,7 +153,7 @@ PHP_METHOD(Value, isPrivate)
 	RETURN_BOOL((o->access & ZEND_ACC_PRIVATE) == ZEND_ACC_PRIVATE);
 }
 
-PHP_METHOD(Value, isProtected)
+PHP_METHOD(Componere_Value, isProtected)
 {
 	php_componere_value_t *o = php_componere_value_fetch(getThis());
 
@@ -162,7 +162,7 @@ PHP_METHOD(Value, isProtected)
 	RETURN_BOOL((o->access & ZEND_ACC_PROTECTED) == ZEND_ACC_PROTECTED);
 }
 
-PHP_METHOD(Value, isStatic)
+PHP_METHOD(Componere_Value, isStatic)
 {
 	php_componere_value_t *o = php_componere_value_fetch(getThis());
 
@@ -171,7 +171,7 @@ PHP_METHOD(Value, isStatic)
 	RETURN_BOOL((o->access & ZEND_ACC_STATIC) == ZEND_ACC_STATIC);
 }
 
-PHP_METHOD(Value, hasDefault)
+PHP_METHOD(Componere_Value, hasDefault)
 {
 	php_componere_value_t *o = php_componere_value_fetch(getThis());
 
@@ -183,7 +183,7 @@ PHP_METHOD(Value, hasDefault)
 PHP_MINIT_FUNCTION(Componere_Value) {
 	zend_class_entry ce;
 
-	INIT_NS_CLASS_ENTRY(ce, "Componere", "Value", class_Value_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Componere", "Value", class_Componere_Value_methods);
 
 	php_componere_value_ce = zend_register_internal_class(&ce);
 	php_componere_value_ce->create_object = php_componere_value_create;

--- a/src/value.stub.php
+++ b/src/value.stub.php
@@ -7,7 +7,7 @@
 
 
 class Value {
-	public function __construct(mixed $value) {}
+	public function __construct(mixed $value = NULL) {}
 
 	public function setProtected():Componere\Value {}
 

--- a/src/value.stub.php
+++ b/src/value.stub.php
@@ -16,9 +16,9 @@ class Value {
 
 	public function setStatic():Value {}
 
-	public function isPrivate():bool {}
-
 	public function isProtected():bool {}
+
+	public function isPrivate():bool {}
 
 	public function isStatic():bool {}
 

--- a/src/value.stub.php
+++ b/src/value.stub.php
@@ -5,15 +5,16 @@
  * @generate-legacy-arginfo
  */
 
+namespace Componere;
 
 class Value {
 	public function __construct(mixed $value = NULL) {}
 
-	public function setProtected():Componere\Value {}
+	public function setProtected():Value {}
 
-	public function setPrivate():Componere\Value {}
+	public function setPrivate():Value {}
 
-	public function setStatic():Componere\Value {}
+	public function setStatic():Value {}
 
 	public function isPrivate():bool {}
 

--- a/src/value.stub.php
+++ b/src/value.stub.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+
+class Value {
+	public function __construct(mixed $value) {}
+
+	public function setProtected():Componere\Value {}
+
+	public function setPrivate():Componere\Value {}
+
+	public function setStatic():Componere\Value {}
+
+	public function isPrivate():bool {}
+
+	public function isProtected():bool {}
+
+	public function isStatic():bool {}
+
+	public function hasDefault():bool {}
+}

--- a/src/value_arginfo.h
+++ b/src/value_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6612c7a30bcfe6b00fe0bc93c1313778a916e9f4 */
+ * Stub hash: f627a979ebea319e7ce9cb170a0b6ead488de72f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_MIXED, 0, "NULL")

--- a/src/value_arginfo.h
+++ b/src/value_arginfo.h
@@ -1,0 +1,45 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 8f33e9df6fc9c5c297d95efff91bdbe6e0c16f07 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Value_setProtected, 0, 0, Componere\\Value, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Value_setPrivate arginfo_class_Value_setProtected
+
+#define arginfo_class_Value_setStatic arginfo_class_Value_setProtected
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Value_isPrivate, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Value_isProtected arginfo_class_Value_isPrivate
+
+#define arginfo_class_Value_isStatic arginfo_class_Value_isPrivate
+
+#define arginfo_class_Value_hasDefault arginfo_class_Value_isPrivate
+
+
+ZEND_METHOD(Value, __construct);
+ZEND_METHOD(Value, setProtected);
+ZEND_METHOD(Value, setPrivate);
+ZEND_METHOD(Value, setStatic);
+ZEND_METHOD(Value, isPrivate);
+ZEND_METHOD(Value, isProtected);
+ZEND_METHOD(Value, isStatic);
+ZEND_METHOD(Value, hasDefault);
+
+
+static const zend_function_entry class_Value_methods[] = {
+	ZEND_ME(Value, __construct, arginfo_class_Value___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, setProtected, arginfo_class_Value_setProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, setPrivate, arginfo_class_Value_setPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, setStatic, arginfo_class_Value_setStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, isPrivate, arginfo_class_Value_isPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, isProtected, arginfo_class_Value_isProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, isStatic, arginfo_class_Value_isStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, hasDefault, arginfo_class_Value_hasDefault, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/src/value_arginfo.h
+++ b/src/value_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f627a979ebea319e7ce9cb170a0b6ead488de72f */
+ * Stub hash: 4533b0e626ad1a7717ecb4af196b81912bbe94a5 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Value___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_MIXED, 0, "NULL")
@@ -12,22 +12,22 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Componere_Value_setStatic arginfo_class_Componere_Value_setProtected
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Value_isPrivate, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Value_isProtected, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Componere_Value_isProtected arginfo_class_Componere_Value_isPrivate
+#define arginfo_class_Componere_Value_isPrivate arginfo_class_Componere_Value_isProtected
 
-#define arginfo_class_Componere_Value_isStatic arginfo_class_Componere_Value_isPrivate
+#define arginfo_class_Componere_Value_isStatic arginfo_class_Componere_Value_isProtected
 
-#define arginfo_class_Componere_Value_hasDefault arginfo_class_Componere_Value_isPrivate
+#define arginfo_class_Componere_Value_hasDefault arginfo_class_Componere_Value_isProtected
 
 
 ZEND_METHOD(Componere_Value, __construct);
 ZEND_METHOD(Componere_Value, setProtected);
 ZEND_METHOD(Componere_Value, setPrivate);
 ZEND_METHOD(Componere_Value, setStatic);
-ZEND_METHOD(Componere_Value, isPrivate);
 ZEND_METHOD(Componere_Value, isProtected);
+ZEND_METHOD(Componere_Value, isPrivate);
 ZEND_METHOD(Componere_Value, isStatic);
 ZEND_METHOD(Componere_Value, hasDefault);
 
@@ -37,8 +37,8 @@ static const zend_function_entry class_Componere_Value_methods[] = {
 	ZEND_ME(Componere_Value, setProtected, arginfo_class_Componere_Value_setProtected, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, setPrivate, arginfo_class_Componere_Value_setPrivate, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, setStatic, arginfo_class_Componere_Value_setStatic, ZEND_ACC_PUBLIC)
-	ZEND_ME(Componere_Value, isPrivate, arginfo_class_Componere_Value_isPrivate, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, isProtected, arginfo_class_Componere_Value_isProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, isPrivate, arginfo_class_Componere_Value_isPrivate, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, isStatic, arginfo_class_Componere_Value_isStatic, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, hasDefault, arginfo_class_Componere_Value_hasDefault, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/src/value_arginfo.h
+++ b/src/value_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f33e9df6fc9c5c297d95efff91bdbe6e0c16f07 */
+ * Stub hash: 6612c7a30bcfe6b00fe0bc93c1313778a916e9f4 */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_MIXED, 0, "NULL")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Value_setProtected, 0, 0, Componere\\Value, 0)

--- a/src/value_arginfo.h
+++ b/src/value_arginfo.h
@@ -1,45 +1,45 @@
 /* This is a generated file, edit the .stub.php file instead.
  * Stub hash: f627a979ebea319e7ce9cb170a0b6ead488de72f */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Value___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_MIXED, 0, "NULL")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Value_setProtected, 0, 0, Componere\\Value, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Componere_Value_setProtected, 0, 0, Componere\\Value, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Value_setPrivate arginfo_class_Value_setProtected
+#define arginfo_class_Componere_Value_setPrivate arginfo_class_Componere_Value_setProtected
 
-#define arginfo_class_Value_setStatic arginfo_class_Value_setProtected
+#define arginfo_class_Componere_Value_setStatic arginfo_class_Componere_Value_setProtected
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Value_isPrivate, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Componere_Value_isPrivate, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Value_isProtected arginfo_class_Value_isPrivate
+#define arginfo_class_Componere_Value_isProtected arginfo_class_Componere_Value_isPrivate
 
-#define arginfo_class_Value_isStatic arginfo_class_Value_isPrivate
+#define arginfo_class_Componere_Value_isStatic arginfo_class_Componere_Value_isPrivate
 
-#define arginfo_class_Value_hasDefault arginfo_class_Value_isPrivate
-
-
-ZEND_METHOD(Value, __construct);
-ZEND_METHOD(Value, setProtected);
-ZEND_METHOD(Value, setPrivate);
-ZEND_METHOD(Value, setStatic);
-ZEND_METHOD(Value, isPrivate);
-ZEND_METHOD(Value, isProtected);
-ZEND_METHOD(Value, isStatic);
-ZEND_METHOD(Value, hasDefault);
+#define arginfo_class_Componere_Value_hasDefault arginfo_class_Componere_Value_isPrivate
 
 
-static const zend_function_entry class_Value_methods[] = {
-	ZEND_ME(Value, __construct, arginfo_class_Value___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, setProtected, arginfo_class_Value_setProtected, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, setPrivate, arginfo_class_Value_setPrivate, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, setStatic, arginfo_class_Value_setStatic, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, isPrivate, arginfo_class_Value_isPrivate, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, isProtected, arginfo_class_Value_isProtected, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, isStatic, arginfo_class_Value_isStatic, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, hasDefault, arginfo_class_Value_hasDefault, ZEND_ACC_PUBLIC)
+ZEND_METHOD(Componere_Value, __construct);
+ZEND_METHOD(Componere_Value, setProtected);
+ZEND_METHOD(Componere_Value, setPrivate);
+ZEND_METHOD(Componere_Value, setStatic);
+ZEND_METHOD(Componere_Value, isPrivate);
+ZEND_METHOD(Componere_Value, isProtected);
+ZEND_METHOD(Componere_Value, isStatic);
+ZEND_METHOD(Componere_Value, hasDefault);
+
+
+static const zend_function_entry class_Componere_Value_methods[] = {
+	ZEND_ME(Componere_Value, __construct, arginfo_class_Componere_Value___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, setProtected, arginfo_class_Componere_Value_setProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, setPrivate, arginfo_class_Componere_Value_setPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, setStatic, arginfo_class_Componere_Value_setStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, isPrivate, arginfo_class_Componere_Value_isPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, isProtected, arginfo_class_Componere_Value_isProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, isStatic, arginfo_class_Componere_Value_isStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, hasDefault, arginfo_class_Componere_Value_hasDefault, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/src/value_legacy_arginfo.h
+++ b/src/value_legacy_arginfo.h
@@ -1,0 +1,44 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 8f33e9df6fc9c5c297d95efff91bdbe6e0c16f07 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 1)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value_setProtected, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Value_setPrivate arginfo_class_Value_setProtected
+
+#define arginfo_class_Value_setStatic arginfo_class_Value_setProtected
+
+#define arginfo_class_Value_isPrivate arginfo_class_Value_setProtected
+
+#define arginfo_class_Value_isProtected arginfo_class_Value_setProtected
+
+#define arginfo_class_Value_isStatic arginfo_class_Value_setProtected
+
+#define arginfo_class_Value_hasDefault arginfo_class_Value_setProtected
+
+
+ZEND_METHOD(Value, __construct);
+ZEND_METHOD(Value, setProtected);
+ZEND_METHOD(Value, setPrivate);
+ZEND_METHOD(Value, setStatic);
+ZEND_METHOD(Value, isPrivate);
+ZEND_METHOD(Value, isProtected);
+ZEND_METHOD(Value, isStatic);
+ZEND_METHOD(Value, hasDefault);
+
+
+static const zend_function_entry class_Value_methods[] = {
+	ZEND_ME(Value, __construct, arginfo_class_Value___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, setProtected, arginfo_class_Value_setProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, setPrivate, arginfo_class_Value_setPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, setStatic, arginfo_class_Value_setStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, isPrivate, arginfo_class_Value_isPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, isProtected, arginfo_class_Value_isProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, isStatic, arginfo_class_Value_isStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Value, hasDefault, arginfo_class_Value_hasDefault, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/src/value_legacy_arginfo.h
+++ b/src/value_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f627a979ebea319e7ce9cb170a0b6ead488de72f */
+ * Stub hash: 4533b0e626ad1a7717ecb4af196b81912bbe94a5 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Value___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, value)
@@ -12,9 +12,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Componere_Value_setStatic arginfo_class_Componere_Value_setProtected
 
-#define arginfo_class_Componere_Value_isPrivate arginfo_class_Componere_Value_setProtected
-
 #define arginfo_class_Componere_Value_isProtected arginfo_class_Componere_Value_setProtected
+
+#define arginfo_class_Componere_Value_isPrivate arginfo_class_Componere_Value_setProtected
 
 #define arginfo_class_Componere_Value_isStatic arginfo_class_Componere_Value_setProtected
 
@@ -25,8 +25,8 @@ ZEND_METHOD(Componere_Value, __construct);
 ZEND_METHOD(Componere_Value, setProtected);
 ZEND_METHOD(Componere_Value, setPrivate);
 ZEND_METHOD(Componere_Value, setStatic);
-ZEND_METHOD(Componere_Value, isPrivate);
 ZEND_METHOD(Componere_Value, isProtected);
+ZEND_METHOD(Componere_Value, isPrivate);
 ZEND_METHOD(Componere_Value, isStatic);
 ZEND_METHOD(Componere_Value, hasDefault);
 
@@ -36,8 +36,8 @@ static const zend_function_entry class_Componere_Value_methods[] = {
 	ZEND_ME(Componere_Value, setProtected, arginfo_class_Componere_Value_setProtected, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, setPrivate, arginfo_class_Componere_Value_setPrivate, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, setStatic, arginfo_class_Componere_Value_setStatic, ZEND_ACC_PUBLIC)
-	ZEND_ME(Componere_Value, isPrivate, arginfo_class_Componere_Value_isPrivate, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, isProtected, arginfo_class_Componere_Value_isProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, isPrivate, arginfo_class_Componere_Value_isPrivate, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, isStatic, arginfo_class_Componere_Value_isStatic, ZEND_ACC_PUBLIC)
 	ZEND_ME(Componere_Value, hasDefault, arginfo_class_Componere_Value_hasDefault, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/src/value_legacy_arginfo.h
+++ b/src/value_legacy_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f33e9df6fc9c5c297d95efff91bdbe6e0c16f07 */
+ * Stub hash: 6612c7a30bcfe6b00fe0bc93c1313778a916e9f4 */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 

--- a/src/value_legacy_arginfo.h
+++ b/src/value_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6612c7a30bcfe6b00fe0bc93c1313778a916e9f4 */
+ * Stub hash: f627a979ebea319e7ce9cb170a0b6ead488de72f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, value)

--- a/src/value_legacy_arginfo.h
+++ b/src/value_legacy_arginfo.h
@@ -1,44 +1,44 @@
 /* This is a generated file, edit the .stub.php file instead.
  * Stub hash: f627a979ebea319e7ce9cb170a0b6ead488de72f */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value___construct, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Value___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Value_setProtected, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Componere_Value_setProtected, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Value_setPrivate arginfo_class_Value_setProtected
+#define arginfo_class_Componere_Value_setPrivate arginfo_class_Componere_Value_setProtected
 
-#define arginfo_class_Value_setStatic arginfo_class_Value_setProtected
+#define arginfo_class_Componere_Value_setStatic arginfo_class_Componere_Value_setProtected
 
-#define arginfo_class_Value_isPrivate arginfo_class_Value_setProtected
+#define arginfo_class_Componere_Value_isPrivate arginfo_class_Componere_Value_setProtected
 
-#define arginfo_class_Value_isProtected arginfo_class_Value_setProtected
+#define arginfo_class_Componere_Value_isProtected arginfo_class_Componere_Value_setProtected
 
-#define arginfo_class_Value_isStatic arginfo_class_Value_setProtected
+#define arginfo_class_Componere_Value_isStatic arginfo_class_Componere_Value_setProtected
 
-#define arginfo_class_Value_hasDefault arginfo_class_Value_setProtected
-
-
-ZEND_METHOD(Value, __construct);
-ZEND_METHOD(Value, setProtected);
-ZEND_METHOD(Value, setPrivate);
-ZEND_METHOD(Value, setStatic);
-ZEND_METHOD(Value, isPrivate);
-ZEND_METHOD(Value, isProtected);
-ZEND_METHOD(Value, isStatic);
-ZEND_METHOD(Value, hasDefault);
+#define arginfo_class_Componere_Value_hasDefault arginfo_class_Componere_Value_setProtected
 
 
-static const zend_function_entry class_Value_methods[] = {
-	ZEND_ME(Value, __construct, arginfo_class_Value___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, setProtected, arginfo_class_Value_setProtected, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, setPrivate, arginfo_class_Value_setPrivate, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, setStatic, arginfo_class_Value_setStatic, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, isPrivate, arginfo_class_Value_isPrivate, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, isProtected, arginfo_class_Value_isProtected, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, isStatic, arginfo_class_Value_isStatic, ZEND_ACC_PUBLIC)
-	ZEND_ME(Value, hasDefault, arginfo_class_Value_hasDefault, ZEND_ACC_PUBLIC)
+ZEND_METHOD(Componere_Value, __construct);
+ZEND_METHOD(Componere_Value, setProtected);
+ZEND_METHOD(Componere_Value, setPrivate);
+ZEND_METHOD(Componere_Value, setStatic);
+ZEND_METHOD(Componere_Value, isPrivate);
+ZEND_METHOD(Componere_Value, isProtected);
+ZEND_METHOD(Componere_Value, isStatic);
+ZEND_METHOD(Componere_Value, hasDefault);
+
+
+static const zend_function_entry class_Componere_Value_methods[] = {
+	ZEND_ME(Componere_Value, __construct, arginfo_class_Componere_Value___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, setProtected, arginfo_class_Componere_Value_setProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, setPrivate, arginfo_class_Componere_Value_setPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, setStatic, arginfo_class_Componere_Value_setStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, isPrivate, arginfo_class_Componere_Value_isPrivate, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, isProtected, arginfo_class_Componere_Value_isProtected, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, isStatic, arginfo_class_Componere_Value_isStatic, ZEND_ACC_PUBLIC)
+	ZEND_ME(Componere_Value, hasDefault, arginfo_class_Componere_Value_hasDefault, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/tests/052.phpt
+++ b/tests/052.phpt
@@ -7,7 +7,7 @@ use Componere\Value;
 new Value(new stdClass, new stdClass);
 ?>
 --EXPECTF--
-Fatal error: Uncaught InvalidArgumentException: value expected in %s:4
+Fatal error: Uncaught InvalidArgumentException: only optional value expected in %s:4
 Stack trace:
 #0 %s(4): Componere\Value->__construct(Object(stdClass), Object(stdClass))
 #1 {main}


### PR DESCRIPTION
@krakjoe please see this

Pros:
- take benefit of PHP 8 feature for maintaining argingo and function entries

Cons:
- compatible PHP 8 and PHP 7
- add type hinting (and return type hinting)
- requires PHP 8 to generate   (master or >= RC2)

What do you think ?

If this make sense, will have to do the other classes